### PR TITLE
Explicit nullability generation fixes

### DIFF
--- a/TypeScript.ContractGenerator.Tests/Files/CustomGenerator/array-types.expected.js
+++ b/TypeScript.ContractGenerator.Tests/Files/CustomGenerator/array-types.expected.js
@@ -1,21 +1,17 @@
 
 export type ArrayRootType = {
     ints?: null | number[];
-    nullableInts?: null | Nullable<number>[];
+    nullableInts?: null | Array<null | number>;
     byteArray?: null | string;
-    nullableByteArray?: null | Nullable<Byte>[];
+    nullableByteArray?: null | Array<null | Byte>;
     enums?: null | AnotherEnum[];
-    nullableEnums?: null | Nullable<AnotherEnum>[];
+    nullableEnums?: null | Array<null | AnotherEnum>;
     strings?: null | string[];
     customTypes?: null | AnotherCustomType[];
     stringsList?: null | string[];
     customTypesDict?: null | {
         [key: string]: AnotherCustomType;
     };
-};
-export type Nullable<T> = {
-    hasValue: boolean;
-    value: T;
 };
 export type Byte = {
 };

--- a/TypeScript.ContractGenerator.Tests/Files/CustomGenerator/array-types.expected.ts
+++ b/TypeScript.ContractGenerator.Tests/Files/CustomGenerator/array-types.expected.ts
@@ -1,21 +1,17 @@
 
 export type ArrayRootType = {
     ints?: null | number[];
-    nullableInts?: null | Nullable<number>[];
+    nullableInts?: null | Array<null | number>;
     byteArray?: null | string;
-    nullableByteArray?: null | Nullable<Byte>[];
+    nullableByteArray?: null | Array<null | Byte>;
     enums?: null | AnotherEnum[];
-    nullableEnums?: null | Nullable<AnotherEnum>[];
+    nullableEnums?: null | Array<null | AnotherEnum>;
     strings?: null | string[];
     customTypes?: null | AnotherCustomType[];
     stringsList?: null | string[];
     customTypesDict?: null | {
         [key in string]?: AnotherCustomType;
     };
-};
-export type Nullable<T> = {
-    hasValue: boolean;
-    value: T;
 };
 export type Byte = {
 };

--- a/TypeScript.ContractGenerator.Tests/Files/Options.Expected/explicit-nullability-disabled.js
+++ b/TypeScript.ContractGenerator.Tests/Files/Options.Expected/explicit-nullability-disabled.js
@@ -1,8 +1,15 @@
 
-export type NotNullRootType = {
+export type ExplicitNullabilityRootType = {
     someNotNullClass: SomeClass;
     someNullableClass?: SomeClass;
     notNullString: string;
+    nullableString?: string;
+    notNullInt: number;
+    nullableInt?: number;
+    notNullArray: number[];
+    nullableArray?: number[];
+    notNullNullablesArray: number[];
+    nullableNullablesArray?: number[];
 };
 export type SomeClass = {
     a: number;

--- a/TypeScript.ContractGenerator.Tests/Files/Options.Expected/explicit-nullability-disabled.ts
+++ b/TypeScript.ContractGenerator.Tests/Files/Options.Expected/explicit-nullability-disabled.ts
@@ -1,8 +1,15 @@
 
-export type NotNullRootType = {
+export type ExplicitNullabilityRootType = {
     someNotNullClass: SomeClass;
     someNullableClass?: SomeClass;
     notNullString: string;
+    nullableString?: string;
+    notNullInt: number;
+    nullableInt?: number;
+    notNullArray: number[];
+    nullableArray?: number[];
+    notNullNullablesArray: number[];
+    nullableNullablesArray?: number[];
 };
 export type SomeClass = {
     a: number;

--- a/TypeScript.ContractGenerator.Tests/Files/Options.Expected/explicit-nullability-enabled.js
+++ b/TypeScript.ContractGenerator.Tests/Files/Options.Expected/explicit-nullability-enabled.js
@@ -1,8 +1,15 @@
 
-export type NotNullRootType = {
+export type ExplicitNullabilityRootType = {
     someNotNullClass: SomeClass;
     someNullableClass?: null | SomeClass;
     notNullString: string;
+    nullableString?: null | string;
+    notNullInt: number;
+    nullableInt?: null | number;
+    notNullArray: number[];
+    nullableArray?: null | number[];
+    notNullNullablesArray: Array<null | number>;
+    nullableNullablesArray?: null | Array<null | number>;
 };
 export type SomeClass = {
     a: number;

--- a/TypeScript.ContractGenerator.Tests/Files/Options.Expected/explicit-nullability-enabled.ts
+++ b/TypeScript.ContractGenerator.Tests/Files/Options.Expected/explicit-nullability-enabled.ts
@@ -1,8 +1,15 @@
 
-export type NotNullRootType = {
+export type ExplicitNullabilityRootType = {
     someNotNullClass: SomeClass;
     someNullableClass?: null | SomeClass;
     notNullString: string;
+    nullableString?: null | string;
+    notNullInt: number;
+    nullableInt?: null | number;
+    notNullArray: number[];
+    nullableArray?: null | number[];
+    notNullNullablesArray: Array<null | number>;
+    nullableNullablesArray?: null | Array<null | number>;
 };
 export type SomeClass = {
     a: number;

--- a/TypeScript.ContractGenerator.Tests/Files/Options.Expected/global-nullable-disabled.js
+++ b/TypeScript.ContractGenerator.Tests/Files/Options.Expected/global-nullable-disabled.js
@@ -2,13 +2,9 @@
 export type GlobalNullableRootType = {
     int: number;
     nullableInt?: null | number;
-    nullableInts?: null | Nullable<number>[];
+    nullableInts?: null | Array<null | number>;
     intGeneric?: null | GenericClass<number>;
-    nullableIntGeneric?: null | GenericClass<Nullable<number>>;
-};
-export type Nullable<T> = {
-    hasValue: boolean;
-    value: T;
+    nullableIntGeneric?: null | GenericClass<null | number>;
 };
 export type GenericClass<T> = {
     genericType?: T;

--- a/TypeScript.ContractGenerator.Tests/Files/Options.Expected/global-nullable-disabled.ts
+++ b/TypeScript.ContractGenerator.Tests/Files/Options.Expected/global-nullable-disabled.ts
@@ -2,13 +2,9 @@
 export type GlobalNullableRootType = {
     int: number;
     nullableInt?: null | number;
-    nullableInts?: null | Nullable<number>[];
+    nullableInts?: null | Array<null | number>;
     intGeneric?: null | GenericClass<number>;
-    nullableIntGeneric?: null | GenericClass<Nullable<number>>;
-};
-export type Nullable<T> = {
-    hasValue: boolean;
-    value: T;
+    nullableIntGeneric?: null | GenericClass<null | number>;
 };
 export type GenericClass<T> = {
     genericType?: T;

--- a/TypeScript.ContractGenerator.Tests/Files/SimpleGenerator/array-types.expected.js
+++ b/TypeScript.ContractGenerator.Tests/Files/SimpleGenerator/array-types.expected.js
@@ -1,19 +1,15 @@
 
 export type ArrayRootType = {
     ints?: null | number[];
-    nullableInts?: null | Nullable<number>[];
+    nullableInts?: null | Array<null | number>;
     byteArray?: null | string;
-    nullableByteArray?: null | Nullable<Byte>[];
+    nullableByteArray?: null | Array<null | Byte>;
     enums?: null | AnotherEnum[];
-    nullableEnums?: null | Nullable<AnotherEnum>[];
+    nullableEnums?: null | Array<null | AnotherEnum>;
     strings?: null | string[];
     customTypes?: null | AnotherCustomType[];
     stringsList?: null | List<string>;
     customTypesDict?: null | Dictionary<string, AnotherCustomType>;
-};
-export type Nullable<T> = {
-    hasValue: boolean;
-    value: T;
 };
 export type Byte = {
 };

--- a/TypeScript.ContractGenerator.Tests/Files/SimpleGenerator/array-types.expected.ts
+++ b/TypeScript.ContractGenerator.Tests/Files/SimpleGenerator/array-types.expected.ts
@@ -1,19 +1,15 @@
 
 export type ArrayRootType = {
     ints?: null | number[];
-    nullableInts?: null | Nullable<number>[];
+    nullableInts?: null | Array<null | number>;
     byteArray?: null | string;
-    nullableByteArray?: null | Nullable<Byte>[];
+    nullableByteArray?: null | Array<null | Byte>;
     enums?: null | AnotherEnum[];
-    nullableEnums?: null | Nullable<AnotherEnum>[];
+    nullableEnums?: null | Array<null | AnotherEnum>;
     strings?: null | string[];
     customTypes?: null | AnotherCustomType[];
     stringsList?: null | List<string>;
     customTypesDict?: null | Dictionary<string, AnotherCustomType>;
-};
-export type Nullable<T> = {
-    hasValue: boolean;
-    value: T;
 };
 export type Byte = {
 };

--- a/TypeScript.ContractGenerator.Tests/Files/SimpleGenerator/generic-types.expected.js
+++ b/TypeScript.ContractGenerator.Tests/Files/SimpleGenerator/generic-types.expected.js
@@ -1,8 +1,8 @@
 
 export type GenericContainingRootType = {
     genericIntChild?: null | GenericChildType<number>;
-    genericNullableIntChild?: null | GenericChildType<Nullable<number>>;
-    arrayGenericNullableIntChild?: null | GenericChildType<Nullable<number>>[];
+    genericNullableIntChild?: null | GenericChildType<null | number>;
+    arrayGenericNullableIntChild?: null | GenericChildType<null | number>[];
     severalGenericParameters?: null | ChildWithSeveralGenericParameters<string, number>;
     genericChildType?: null | GenericChildType<ChildWithConstraint<string>>;
     genericHell?: null | GenericChildType<ChildWithConstraint<GenericChildType<string>>>;
@@ -10,10 +10,6 @@ export type GenericContainingRootType = {
 export type GenericChildType<T> = {
     childType?: T;
     childTypes?: null | T[];
-};
-export type Nullable<T> = {
-    hasValue: boolean;
-    value: T;
 };
 export type ChildWithSeveralGenericParameters<T1, T2> = {
     item1?: T1;

--- a/TypeScript.ContractGenerator.Tests/Files/SimpleGenerator/generic-types.expected.ts
+++ b/TypeScript.ContractGenerator.Tests/Files/SimpleGenerator/generic-types.expected.ts
@@ -1,8 +1,8 @@
 
 export type GenericContainingRootType = {
     genericIntChild?: null | GenericChildType<number>;
-    genericNullableIntChild?: null | GenericChildType<Nullable<number>>;
-    arrayGenericNullableIntChild?: null | GenericChildType<Nullable<number>>[];
+    genericNullableIntChild?: null | GenericChildType<null | number>;
+    arrayGenericNullableIntChild?: null | GenericChildType<null | number>[];
     severalGenericParameters?: null | ChildWithSeveralGenericParameters<string, number>;
     genericChildType?: null | GenericChildType<ChildWithConstraint<string>>;
     genericHell?: null | GenericChildType<ChildWithConstraint<GenericChildType<string>>>;
@@ -10,10 +10,6 @@ export type GenericContainingRootType = {
 export type GenericChildType<T> = {
     childType?: T;
     childTypes?: null | T[];
-};
-export type Nullable<T> = {
-    hasValue: boolean;
-    value: T;
 };
 export type ChildWithSeveralGenericParameters<T1, T2> = {
     item1?: T1;

--- a/TypeScript.ContractGenerator.Tests/OptionsTests.cs
+++ b/TypeScript.ContractGenerator.Tests/OptionsTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 
 using FluentAssertions;
@@ -39,7 +38,7 @@ namespace SkbKontur.TypeScript.ContractGenerator.Tests
         [TestCase(false, "explicit-nullability-disabled")]
         public void ExplicitNullabilityTest(bool explicitNullabilityEnabled, string expectedFileName)
         {
-            var generatedCode = GenerateCode(new FlowTypeGenerationOptions {EnableExplicitNullability = explicitNullabilityEnabled}, CustomTypeGenerator.Null, typeof(NotNullRootType)).Single().Replace("\r\n", "\n");
+            var generatedCode = GenerateCode(new FlowTypeGenerationOptions {EnableExplicitNullability = explicitNullabilityEnabled}, CustomTypeGenerator.Null, typeof(ExplicitNullabilityRootType)).Single().Replace("\r\n", "\n");
             var expectedCode = GetExpectedCode($"Options.Expected/{expectedFileName}");
             generatedCode.Should().Be(expectedCode);
         }

--- a/TypeScript.ContractGenerator.Tests/Types/ExplicitNullabilityRootType.cs
+++ b/TypeScript.ContractGenerator.Tests/Types/ExplicitNullabilityRootType.cs
@@ -1,0 +1,29 @@
+namespace SkbKontur.TypeScript.ContractGenerator.Tests.Types
+{
+    public class ExplicitNullabilityRootType
+    {
+        [NotNull]
+        public SomeClass SomeNotNullClass { get; set; }
+
+        public SomeClass SomeNullableClass { get; set; }
+
+        [NotNull]
+        public string NotNullString { get; set; }
+
+        public string NullableString { get; set; }
+
+        public int NotNullInt { get; set; }
+
+        public int? NullableInt { get; set; }
+
+        [NotNull]
+        public int[] NotNullArray { get; set; }
+
+        public int[] NullableArray { get; set; }
+
+        [NotNull]
+        public int?[] NotNullNullablesArray { get; set; }
+
+        public int?[] NullableNullablesArray { get; set; }
+    }
+}

--- a/TypeScript.ContractGenerator/CodeDom/FlowTypeArrayType.cs
+++ b/TypeScript.ContractGenerator/CodeDom/FlowTypeArrayType.cs
@@ -7,11 +7,15 @@ namespace SkbKontur.TypeScript.ContractGenerator.CodeDom
             ItemType = itemType;
         }
 
-        public FlowTypeType ItemType { get; private set; }
+        private FlowTypeType ItemType { get; }
 
         public override string GenerateCode(ICodeGenerationContext context)
         {
-            return ItemType.GenerateCode(context) + "[]";
+            var innerTypeCode = ItemType.GenerateCode(context);
+            if (!(ItemType is FlowTypeUnionType))
+                return innerTypeCode + "[]";
+
+            return $"Array<{innerTypeCode}>";
         }
     }
 }

--- a/TypeScript.ContractGenerator/CodeDom/FlowTypeOrNullType.cs
+++ b/TypeScript.ContractGenerator/CodeDom/FlowTypeOrNullType.cs
@@ -1,0 +1,14 @@
+namespace SkbKontur.TypeScript.ContractGenerator.CodeDom
+{
+    public class FlowTypeOrNullType : FlowTypeUnionType
+    {
+        public FlowTypeOrNullType(FlowTypeType innerType)
+            : base(new[]
+                {
+                    new FlowTypeBuildInType("null"),
+                    innerType
+                })
+        {
+        }
+    }
+}

--- a/TypeScript.ContractGenerator/FlowTypeGenerator.cs
+++ b/TypeScript.ContractGenerator/FlowTypeGenerator.cs
@@ -98,8 +98,13 @@ namespace SkbKontur.TypeScript.ContractGenerator
                            : new TypeScriptEnumTypeBuildingContext(targetUnit, type);
             }
 
-            if (options.UseGlobalNullable && type.IsGenericType && !type.IsGenericTypeDefinition && type.GetGenericTypeDefinition() == typeof(Nullable<>))
-                return new NullableTypeBuildingContext(type);
+            if (type.IsGenericType && !type.IsGenericTypeDefinition && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                var underlyingType = type.GenericTypeArguments.Single();
+                if (options.EnableExplicitNullability)
+                    return new NullableTypeBuildingContext(underlyingType, options.UseGlobalNullable);
+                return GetTypeBuildingContext(typeLocation, underlyingType);
+            }
 
             if (type.IsGenericType && !type.IsGenericTypeDefinition)
                 return new GenericTypeTypeBuildingContext(type);

--- a/TypeScript.ContractGenerator/TypeBuilders/CustomTypeTypeBuildingContext.cs
+++ b/TypeScript.ContractGenerator/TypeBuilders/CustomTypeTypeBuildingContext.cs
@@ -73,23 +73,12 @@ namespace SkbKontur.TypeScript.ContractGenerator.TypeBuilders
                 return new FlowTypeTypeReference(property.PropertyType.Name);
 
             if (isNullable && options.EnableExplicitNullability && !options.UseGlobalNullable)
-                return OrNull(propertyType);
+                return new FlowTypeOrNullType(propertyType);
 
             if (isNullable && options.EnableExplicitNullability && options.UseGlobalNullable)
                 return new FlowTypeNullableType(propertyType);
 
             return propertyType;
-        }
-
-        private static FlowTypeUnionType OrNull(FlowTypeType buildAndImportType)
-        {
-            return new FlowTypeUnionType(
-                new[]
-                    {
-                        new FlowTypeBuildInType("null"),
-                        buildAndImportType
-                    }
-                );
         }
 
         private static string BuildPropertyName(string propertyName)

--- a/TypeScript.ContractGenerator/TypeBuilders/NullableTypeBuildingContext.cs
+++ b/TypeScript.ContractGenerator/TypeBuilders/NullableTypeBuildingContext.cs
@@ -6,9 +6,10 @@ namespace SkbKontur.TypeScript.ContractGenerator.TypeBuilders
 {
     public class NullableTypeBuildingContext : ITypeBuildingContext
     {
-        public NullableTypeBuildingContext(Type nullableType)
+        public NullableTypeBuildingContext(Type nullableUnderlyingType, bool useGlobalNullable)
         {
-            itemType = nullableType.GetGenericArguments()[0];
+            itemType = nullableUnderlyingType;
+            this.useGlobalNullable = useGlobalNullable;
         }
 
         public bool IsDefinitionBuilt => true;
@@ -24,9 +25,12 @@ namespace SkbKontur.TypeScript.ContractGenerator.TypeBuilders
         public FlowTypeType ReferenceFrom(FlowTypeUnit targetUnit, ITypeGenerator typeGenerator)
         {
             var itemFlowType = typeGenerator.ResolveType(itemType).ReferenceFrom(targetUnit, typeGenerator);
-            return new FlowTypeNullableType(itemFlowType);
+            return useGlobalNullable
+                       ? (FlowTypeType)new FlowTypeNullableType(itemFlowType)
+                       : new FlowTypeOrNullType(itemFlowType);
         }
 
         private readonly Type itemType;
+        private readonly bool useGlobalNullable;
     }
 }


### PR DESCRIPTION
Arrays containing union types generates as `Array<a | b>`
Explicit nullability affects CLR Nullable<> type