### PR TITLE
Fixed bug with abstract class inheritance

### DIFF
--- a/TypeScript.ContractGenerator.Tests/EndToEndTests.cs
+++ b/TypeScript.ContractGenerator.Tests/EndToEndTests.cs
@@ -58,6 +58,7 @@ namespace SkbKontur.TypeScript.ContractGenerator.Tests
         [TestCase(typeof(SimpleNullableRootType), typeof(TestCustomTypeGenerator), "nullable-types")]
         [TestCase(typeof(ArrayRootType), typeof(TestCustomTypeGenerator), "array-types")]
         [TestCase(typeof(EnumWithConstGetterContainingRootType), typeof(TestCustomPropertyResolver), "custom-property-resolver")]
+        [TestCase(typeof(FirstInheritor), typeof(TestCustomTypeGenerator), "inherit-abstract-class")]
         [TestCase(typeof(AbstractClassRootType), typeof(TestCustomTypeGenerator), "abstract-class")]
         public void CustomGeneratorTest(Type rootType, Type type, string expectedFileName)
         {

--- a/TypeScript.ContractGenerator.Tests/Files/CustomGenerator/inherit-abstract-class.js
+++ b/TypeScript.ContractGenerator.Tests/Files/CustomGenerator/inherit-abstract-class.js
@@ -1,0 +1,8 @@
+
+export type FirstInheritor = {
+    a: number;
+};
+export type SecondInheritor = {
+    a?: null | string;
+};
+export type AbstractClass = FirstInheritor | SecondInheritor;

--- a/TypeScript.ContractGenerator.Tests/Files/CustomGenerator/inherit-abstract-class.ts
+++ b/TypeScript.ContractGenerator.Tests/Files/CustomGenerator/inherit-abstract-class.ts
@@ -1,0 +1,8 @@
+
+export type FirstInheritor = {
+    a: number;
+};
+export type SecondInheritor = {
+    a?: null | string;
+};
+export type AbstractClass = FirstInheritor | SecondInheritor;

--- a/TypeScript.ContractGenerator.Tests/TypeScript.ContractGenerator.Tests.csproj
+++ b/TypeScript.ContractGenerator.Tests/TypeScript.ContractGenerator.Tests.csproj
@@ -25,6 +25,12 @@
       <None CopyToOutputDirectory="Always" Update="Files\CustomGenerator\abstract-class.ts" />
       <None CopyToOutputDirectory="Always" Update="Files\CustomGenerator\custom-property-resolver.js" />
       <None CopyToOutputDirectory="Always" Update="Files\CustomGenerator\custom-property-resolver.ts" />
+      <None Update="Files\CustomGenerator\inherit-abstract-class.js">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
+      <None Update="Files\CustomGenerator\inherit-abstract-class.ts">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
       <None CopyToOutputDirectory="Always" Update="Files\CustomGenerator\nullable-types.js" />
       <None CopyToOutputDirectory="Always" Update="Files\CustomGenerator\nullable-types.ts" />
       <None CopyToOutputDirectory="Always" Update="Files\CustomGenerator\simple-types.js" />

--- a/TypeScript.ContractGenerator/TypeBuilders/CustomTypeTypeBuildingContext.cs
+++ b/TypeScript.ContractGenerator/TypeBuilders/CustomTypeTypeBuildingContext.cs
@@ -36,12 +36,13 @@ namespace SkbKontur.TypeScript.ContractGenerator.TypeBuilders
 
         public override void Initialize(ITypeGenerator typeGenerator)
         {
+            Declaration = CreateComplexTypeScriptDeclarationWithoutDefinition(Type);
+            Unit.Body.Add(new TypeScriptExportTypeStatement {Declaration = Declaration});
+
             if (Type.BaseType != typeof(object) && Type.BaseType != typeof(ValueType) && Type.BaseType != typeof(MarshalByRefObject) && Type.BaseType != null)
             {
                 typeGenerator.ResolveType(Type.BaseType);
             }
-            Declaration = CreateComplexTypeScriptDeclarationWithoutDefinition(Type);
-            Unit.Body.Add(new TypeScriptExportTypeStatement {Declaration = Declaration});
         }
 
         public override void BuildDefinition(ITypeGenerator typeGenerator)


### PR DESCRIPTION
Fixed bug with abstract class inheritance when generating code for child types.

Exapmple, using AbstractTypeBuildingContext from test project and resolve type FirstInheritor inherit from abstract class AbstractClassRootType.

After run, waiting resolved FirstInheritor and all childs of AbstractClassRootType, but throws exception error.