### PR TITLE
Fixes path combination error in Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Then generate TypeScript files with:
 
 ```csharp
 var generator = new TypeScriptGenerator(TypeScriptGenerationOptions.Default, CustomTypeGenerator.Null, new RootTypesProvider(typeof(SecondType)));
-generator.GenerateFiles("./output");
+generatorGenerateFiles(Path.Combine(Directory.GetCurrentDirectory(), "output"));
 ```
 
 By default, this will generate file with name `.ts` with following content:


### PR DESCRIPTION
Path.Combine is used by FilesGenerator which results in @"./output\filename.ts" in Windows which leads to undefined results