### PR TITLE
Add NET8 support, fix various tests on non-Windows platforms

### DIFF
--- a/AspNetCoreExample.Generator/AspNetCoreExample.Generator.csproj
+++ b/AspNetCoreExample.Generator/AspNetCoreExample.Generator.csproj
@@ -17,4 +17,9 @@
     <TypeScriptCompile Include="output\**\*.ts" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/TypeScript.ContractGenerator.Cli/TypeScript.ContractGenerator.Cli.csproj
+++ b/TypeScript.ContractGenerator.Cli/TypeScript.ContractGenerator.Cli.csproj
@@ -12,6 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TypeScript.ContractGenerator.Cli/TypeScript.ContractGenerator.Cli.csproj
+++ b/TypeScript.ContractGenerator.Cli/TypeScript.ContractGenerator.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>SkbKontur.TypeScript.ContractGenerator.Cli</AssemblyName>
     <RootNamespace>SkbKontur.TypeScript.ContractGenerator.Cli</RootNamespace>
     <PackageId>SkbKontur.TypeScript.ContractGenerator.Cli</PackageId>

--- a/TypeScript.ContractGenerator.Roslyn/TypeScript.ContractGenerator.Roslyn.csproj
+++ b/TypeScript.ContractGenerator.Roslyn/TypeScript.ContractGenerator.Roslyn.csproj
@@ -12,7 +12,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/TypeScript.ContractGenerator.Tests/CustomTypeGenerators/SimpleStructureTypeLocator.cs
+++ b/TypeScript.ContractGenerator.Tests/CustomTypeGenerators/SimpleStructureTypeLocator.cs
@@ -1,3 +1,5 @@
+using System.IO;
+
 using SkbKontur.TypeScript.ContractGenerator.Abstractions;
 using SkbKontur.TypeScript.ContractGenerator.CodeDom;
 using SkbKontur.TypeScript.ContractGenerator.TypeBuilders;
@@ -8,7 +10,7 @@ namespace SkbKontur.TypeScript.ContractGenerator.Tests.CustomTypeGenerators
     {
         public string GetTypeLocation(ITypeInfo type)
         {
-            return $"{type.Name}\\{type.Name}";
+            return $"{type.Name}{Path.DirectorySeparatorChar}{type.Name}";
         }
 
         public ITypeBuildingContext? ResolveType(string initialUnitPath, ITypeGenerator typeGenerator, ITypeInfo type, ITypeScriptUnitFactory unitFactory)

--- a/TypeScript.ContractGenerator.Tests/TypeScript.ContractGenerator.Tests.csproj
+++ b/TypeScript.ContractGenerator.Tests/TypeScript.ContractGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0;net7.0;net8.0</TargetFrameworks>
     <AssemblyName>SkbKontur.TypeScript.ContractGenerator.Tests</AssemblyName>
     <RootNamespace>SkbKontur.TypeScript.ContractGenerator.Tests</RootNamespace>
   </PropertyGroup>

--- a/TypeScript.ContractGenerator.Tests/TypeScript.ContractGenerator.Tests.csproj
+++ b/TypeScript.ContractGenerator.Tests/TypeScript.ContractGenerator.Tests.csproj
@@ -11,12 +11,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiffPlex" Version="1.7.1" />
-    <PackageReference Include="FluentAssertions" Version="6.11.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="DiffPlex" Version="1.7.2" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TypeScript.ContractGenerator/TypeScript.ContractGenerator.csproj
+++ b/TypeScript.ContractGenerator/TypeScript.ContractGenerator.csproj
@@ -7,4 +7,9 @@
     <PackageId>SkbKontur.TypeScript.ContractGenerator</PackageId>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.6.133" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.0",
+    "version": "8.0.0",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Hia, I am using your library in a project that requires it with .NET8 support, so I took the liberty of updating it! Btw, thank you for your work on this library! ☺️

What did I do:

1. Add .NET8 as supported TargetFramework
2. Update all relevant dependencies
3. Fix CLI tests on non-Windows platforms
4. Fix SimpleStructureTypeLocator on non-Windows platforms

Should you have any questions or comments, please let me know any time!